### PR TITLE
Use .iter() in a few more for loops. Also uses a better .min and .max for f32

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -49,11 +49,60 @@ impl Vec2Helper for Vec2 {
         // Check if the point is in the segment's bounding box and then check if it is on the line.
         // Just checking if the point is on the line is not sufficient because the point can be
         // outside the segment but still be on the line.
-        (segment.0.x.min(segment.1.x)..=segment.0.x.max(segment.1.x)).contains(&self.x)
-            && (segment.0.y.min(segment.1.y)..=segment.0.y.max(segment.1.y)).contains(&self.y)
+        (min(segment.0.x, segment.1.x)..=max(segment.0.x, segment.1.x)).contains(&self.x)
+            && (min(segment.0.y, segment.1.y)..=max(segment.0.y, segment.1.y)).contains(&self.y)
             && (self.side(segment) == EdgeSide::Edge)
     }
 }
+
+/// Fast floating point minimum.  This function matches the semantics of
+///
+/// ```no_compile
+/// if x < y { x } else { y }
+/// ```
+///
+/// which has efficient instruction sequences on many platforms (1 instruction on x86).  For most
+/// values, it matches the semantics of `x.min(y)`; the special cases are:
+///
+/// ```text
+/// min(-0.0, +0.0); +0.0
+/// min(+0.0, -0.0): -0.0
+/// min( NaN,  1.0):  1.0
+/// min( 1.0,  NaN):  NaN
+/// ```
+#[inline(always)]
+pub(crate) fn min(x: f32, y: f32) -> f32 {
+    if x < y {
+        x
+    } else {
+        y
+    }
+}
+
+/// Fast floating point maximum.  This function matches the semantics of
+///
+/// ```no_compile
+/// if x > y { x } else { y }
+/// ```
+///
+/// which has efficient instruction sequences on many platforms (1 instruction on x86).  For most
+/// values, it matches the semantics of `x.max(y)`; the special cases are:
+///
+/// ```text
+/// max(-0.0, +0.0); +0.0
+/// max(+0.0, -0.0): -0.0
+/// max( NaN,  1.0):  1.0
+/// max( 1.0,  NaN):  NaN
+/// ```
+#[inline(always)]
+pub(crate) fn max(x: f32, y: f32) -> f32 {
+    if x > y {
+        x
+    } else {
+        y
+    }
+}
+
 
 /// Computes heuristic distance from a [`super::SearchNode`] represented by the given root and interval to the goal.
 #[cfg_attr(feature = "tracing", instrument(skip_all))]

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -103,7 +103,6 @@ pub(crate) fn max(x: f32, y: f32) -> f32 {
     }
 }
 
-
 /// Computes heuristic distance from a [`super::SearchNode`] represented by the given root and interval to the goal.
 #[cfg_attr(feature = "tracing", instrument(skip_all))]
 #[inline(always)]

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -327,7 +327,7 @@ impl<'m> SearchInstance<'m> {
                 self.debug = true;
                 self.fail_fast = 3;
             }
-            for successor in self.edges_between(&node) {
+            for successor in self.edges_between(&node).iter() {
                 let start = self.mesh.vertices.get(successor.edge.0).unwrap();
                 let end = self.mesh.vertices.get(successor.edge.1).unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,7 +280,7 @@ impl Mesh {
             g: 0.0,
         };
 
-        for edge in starting_polygon.edges_index() {
+        for edge in starting_polygon.edges_index().iter() {
             let start = if let Some(v) = self.vertices.get(edge.0) {
                 v
             } else {
@@ -520,7 +520,7 @@ impl Mesh {
     #[inline(always)]
     fn point_in_polygon(&self, point: Vec2, polygon: &Polygon) -> bool {
         let mut edged = false;
-        for edge in polygon.edges_index() {
+        for edge in polygon.edges_index().iter() {
             if edge.0.max(edge.1) >= self.vertices.len() {
                 return false;
             }


### PR DESCRIPTION
These changes combined give me a repeatable ~3-4% speedup over current main. There's probably another 5% available by rewriting some of the existing for loops as iter chains, but the early returns make it annoying/non trivial.

See the comments in https://github.com/svenstaro/bvh/pull/87 for the f32 asm comparison between std .min() and .max() and the included functions in this pr.