### PR TITLE
adding benches on path failures and on point detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,11 @@ tracing = "0.1"
 [[bench]]
 name = "path"
 harness = false
+
+[[bench]]
+name = "no_path"
+harness = false
+
+[[bench]]
+name = "is_in_mesh"
+harness = false

--- a/benches/is_in_mesh.rs
+++ b/benches/is_in_mesh.rs
@@ -1,0 +1,47 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use glam::Vec2;
+use polyanya::Mesh;
+
+fn is_in_mesh(c: &mut Criterion) {
+    let mesh = Mesh::from_file("meshes/aurora-merged.mesh".into());
+
+    [
+        Vec2::new(575., 410.),
+        Vec2::new(728., 148.),
+        Vec2::new(131., 669.),
+        Vec2::new(135., 360.),
+        Vec2::new(308., 147.),
+        Vec2::new(22., 432.),
+    ]
+    .iter()
+    .for_each(|from| {
+        c.bench_function(&format!("is in mesh {:?}", from), |b| {
+            b.iter(|| {
+                assert!(black_box(mesh.point_in_mesh(*from)));
+            })
+        });
+    });
+}
+
+fn is_not_in_mesh(c: &mut Criterion) {
+    let mesh = Mesh::from_file("meshes/aurora-merged.mesh".into());
+
+    [
+        Vec2::new(0., 0.),
+        Vec2::new(297., 438.),
+        Vec2::new(726., 470.),
+        Vec2::new(969., 726.),
+        Vec2::new(521., 90.),
+    ]
+    .iter()
+    .for_each(|from| {
+        c.bench_function(&format!("is not in mesh {:?}", from), |b| {
+            b.iter(|| {
+                assert!(black_box(!mesh.point_in_mesh(*from)));
+            })
+        });
+    });
+}
+
+criterion_group!(benches, is_in_mesh, is_not_in_mesh);
+criterion_main!(benches);

--- a/benches/no_path.rs
+++ b/benches/no_path.rs
@@ -1,0 +1,27 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use glam::Vec2;
+use polyanya::Mesh;
+
+fn get_path(c: &mut Criterion) {
+    let mesh = Mesh::from_file("meshes/aurora-merged.mesh".into());
+
+    [
+        (Vec2::new(0.0, 0.0), Vec2::new(0.0, 0.0)),
+        (Vec2::new(0.0, 0.0), Vec2::new(575.0, 410.0)),
+        (Vec2::new(575.0, 410.0), Vec2::new(0.0, 0.0)),
+        (Vec2::new(297.0, 438.0), Vec2::new(575.0, 410.0)),
+        (Vec2::new(458.0, 47.0), Vec2::new(575.0, 410.0)),
+        (Vec2::new(575.0, 410.0), Vec2::new(458.0, 47.0)), // worst case: destination is in a small unreachable zone
+    ]
+    .iter()
+    .for_each(|(from, to)| {
+        c.bench_function(&format!("get path {:?}-{:?}", from, to), |b| {
+            b.iter(|| {
+                assert_eq!(black_box(mesh.path(*from, *to)), None);
+            })
+        });
+    });
+}
+
+criterion_group!(benches, get_path);
+criterion_main!(benches);


### PR DESCRIPTION
adding benches:
* for path that are not possible (points are not in mesh, or points are not in interconnected zones)
* for finding a point in the mesh
* for finding a point not in the mesh