### PR TITLE
Some more perf improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ tracing-tracy = "0.10"
 tracing-subscriber = "0.3"
 tracing = "0.1"
 
+[lib]
+bench = false
 
 [[bench]]
 name = "path"

--- a/src/async_helpers.rs
+++ b/src/async_helpers.rs
@@ -49,11 +49,11 @@ impl<'m> Future for FuturePath<'m> {
             let start = Instant::now();
 
             let starting_polygon_index = self.mesh.get_point_location(self.from);
-            if starting_polygon_index == usize::MAX {
+            if starting_polygon_index == u32::MAX {
                 return Poll::Ready(None);
             }
             let ending_polygon = self.mesh.get_point_location(self.to);
-            if ending_polygon == usize::MAX {
+            if ending_polygon == u32::MAX {
                 return Poll::Ready(None);
             }
 

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -267,9 +267,12 @@ impl<'m> SearchInstance<'m> {
             }
             // Bounds are checked just before
             #[allow(unsafe_code)]
-            let start = unsafe { self.mesh.vertices.get_unchecked(edge.0) };
-            #[allow(unsafe_code)]
-            let end = unsafe { self.mesh.vertices.get_unchecked(edge.1) };
+            let (start, end) = unsafe {
+                (
+                    self.mesh.vertices.get_unchecked(edge.0 as usize),
+                    self.mesh.vertices.get_unchecked(edge.1 as usize),
+                )
+            };
             let mut start_point = start.coords;
             let end_point = end.coords;
 
@@ -498,8 +501,14 @@ impl<'m> SearchInstance<'m> {
                 self.fail_fast = 3;
             }
             for successor in self.edges_between(&node).iter() {
-                let start = self.mesh.vertices.get(successor.edge.0).unwrap();
-                let end = self.mesh.vertices.get(successor.edge.1).unwrap();
+                // we know they exist, it's checked in `edges_between`
+                #[allow(unsafe_code)]
+                let (start, end) = unsafe {
+                    (
+                        self.mesh.vertices.get_unchecked(successor.edge.0 as usize),
+                        self.mesh.vertices.get_unchecked(successor.edge.1 as usize),
+                    )
+                };
 
                 #[cfg(debug_assertions)]
                 if self.debug {

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -32,7 +32,7 @@ enum SuccessorType {
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub(crate) struct Successor {
     interval: (Vec2, Vec2),
-    edge: (usize, usize),
+    edge: (u32, u32),
     ty: SuccessorType,
 }
 
@@ -47,15 +47,15 @@ pub(crate) struct SearchInstance<'m> {
     #[cfg(feature = "stats")]
     pub(crate) start: Instant,
     #[cfg(feature = "stats")]
-    pub(crate) pushed: usize,
+    pub(crate) pushed: u32,
     #[cfg(feature = "stats")]
-    pub(crate) popped: usize,
+    pub(crate) popped: u32,
     #[cfg(feature = "stats")]
-    pub(crate) successors_called: usize,
+    pub(crate) successors_called: u32,
     #[cfg(feature = "stats")]
-    pub(crate) nodes_generated: usize,
+    pub(crate) nodes_generated: u32,
     #[cfg(feature = "stats")]
-    pub(crate) nodes_pruned_post_pop: usize,
+    pub(crate) nodes_pruned_post_pop: u32,
     #[cfg(debug_assertions)]
     pub(crate) debug: bool,
     #[cfg(debug_assertions)]
@@ -71,11 +71,11 @@ pub(crate) enum InstanceStep {
 impl<'m> SearchInstance<'m> {
     pub(crate) fn setup(
         mesh: &'m Mesh,
-        from: (Vec2, usize),
-        to: (Vec2, usize),
+        from: (Vec2, u32),
+        to: (Vec2, u32),
         #[cfg(feature = "stats")] start: Instant,
     ) -> Self {
-        let starting_polygon = &mesh.polygons[from.1];
+        let starting_polygon = &mesh.polygons[from.1 as usize];
 
         let mut search_instance = SearchInstance {
             queue: BinaryHeap::with_capacity(15),
@@ -116,12 +116,12 @@ impl<'m> SearchInstance<'m> {
         };
 
         for edge in starting_polygon.edges_index().iter() {
-            let start = if let Some(v) = mesh.vertices.get(edge.0) {
+            let start = if let Some(v) = mesh.vertices.get(edge.0 as usize) {
                 v
             } else {
                 continue;
             };
-            let end = if let Some(v) = mesh.vertices.get(edge.1) {
+            let end = if let Some(v) = mesh.vertices.get(edge.1 as usize) {
                 v
             } else {
                 continue;
@@ -262,7 +262,7 @@ impl<'m> SearchInstance<'m> {
 
         let mut ty = SuccessorType::RightNonObservable;
         for edge in &polygon.double_edges_index()[right_index..=left_index] {
-            if edge.0.max(edge.1) > self.mesh.vertices.len() {
+            if edge.0.max(edge.1) as usize > self.mesh.vertices.len() {
                 continue;
             }
             // Bounds are checked just before
@@ -291,7 +291,6 @@ impl<'m> SearchInstance<'m> {
                 );
             }
 
-            let end_root_int1 = end_point.side((node.root, node.interval.1));
             match start_point.side((node.root, node.interval.0)) {
                 EdgeSide::Right => {
                     if let Some(intersect) = line_intersect_segment(
@@ -341,6 +340,8 @@ impl<'m> SearchInstance<'m> {
             }
             let mut end_intersection_p = None;
             let mut found_intersection = false;
+            let end_root_int1 = end_point.side((node.root, node.interval.1));
+
             if end_root_int1 == EdgeSide::Left {
                 if let Some(intersect) =
                     line_intersect_segment((node.root, node.interval.1), (start_point, end_point))
@@ -403,8 +404,8 @@ impl<'m> SearchInstance<'m> {
         &mut self,
         root: Vec2,
         other_side: isize,
-        start: (Vec2, usize),
-        end: (Vec2, usize),
+        start: (Vec2, u32),
+        end: (Vec2, u32),
         node: &SearchNode,
     ) {
         #[cfg(feature = "stats")]
@@ -563,7 +564,7 @@ impl<'m> SearchInstance<'m> {
                             }
                             continue;
                         }
-                        let vertex = self.mesh.vertices.get(node.edge.0).unwrap();
+                        let vertex = self.mesh.vertices.get(node.edge.0 as usize).unwrap();
                         if vertex.is_corner
                             && vertex.coords.distance_squared(node.interval.0) < EPSILON
                         {
@@ -585,7 +586,7 @@ impl<'m> SearchInstance<'m> {
                             }
                             continue;
                         }
-                        let vertex = self.mesh.vertices.get(node.edge.1).unwrap();
+                        let vertex = self.mesh.vertices.get(node.edge.1 as usize).unwrap();
                         if vertex.is_corner
                             && vertex.coords.distance_squared(node.interval.1) < EPSILON
                         {

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -126,12 +126,11 @@ impl<'m> SearchInstance<'m> {
             } else {
                 continue;
             };
-            let mut other_side = isize::MAX;
-            for i in &start.polygons {
-                if *i != -1 && *i != from.1 as isize && end.polygons.contains(i) {
-                    other_side = *i;
-                }
-            }
+            let other_side = *start
+                .polygons
+                .iter()
+                .find(|i| **i != -1 && **i != from.1 as isize && end.polygons.contains(*i))
+                .unwrap_or(&isize::MAX);
 
             if other_side == to.1 as isize
                 || (other_side != isize::MAX
@@ -507,13 +506,11 @@ impl<'m> SearchInstance<'m> {
                     println!("v {:?}", successor);
                 }
 
-                let mut other_side = isize::MAX;
-                // find the polygon at the other side of this edge
-                for i in &start.polygons {
-                    if *i != -1 && *i != node.polygon_to && end.polygons.contains(i) {
-                        other_side = *i;
-                    }
-                }
+                let other_side = *start
+                    .polygons
+                    .iter()
+                    .find(|i| **i != -1 && **i != node.polygon_to && end.polygons.contains(*i))
+                    .unwrap_or(&isize::MAX);
 
                 #[cfg(debug_assertions)]
                 if self.debug {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -412,14 +412,13 @@ impl Mesh {
     #[cfg_attr(feature = "tracing", instrument(skip_all))]
     fn get_point_location_unit_baked(&self, point: Vec2) -> usize {
         let mut visited = HashSet::new();
-        let mut peekable = self.baked_polygons_x.iter().peekable();
-        while let Some(baked) = peekable.next() {
-            if let Some((next, _)) = peekable.peek() {
-                if **next > (point.x * PRECISION) as i32 {
-                    for i in baked.1.iter() {
-                        if visited.insert(i) && self.point_in_polygon(point, &self.polygons[*i]) {
-                            return *i;
-                        }
+        for baked in self.baked_polygons_x.iter() {
+            if *baked.0 > (point.x * PRECISION) as i32 {
+                for i in baked.1.iter() {
+                    if visited.insert(i)
+                        && self.point_in_polygon(point, &self.polygons[*i as usize])
+                    {
+                        return *i;
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -438,8 +438,14 @@ impl Mesh {
                 return false;
             }
             edged = true;
-            let last = self.vertices[edge.0].coords;
-            let next = self.vertices[edge.1].coords;
+            // Bounds are checked just before
+            #[allow(unsafe_code)]
+            let (last, next) = unsafe {
+                (
+                    self.vertices.get_unchecked(edge.0 as usize).coords,
+                    self.vertices.get_unchecked(edge.1 as usize).coords,
+                )
+            };
 
             let current_side = point.side((last, next));
             if current_side == EdgeSide::Edge && point.on_segment((last, next)) {


### PR DESCRIPTION
* when searching for the polygon on the other side of the edge, stop as soon as it's found instead of going through all the vertices neighbours
* no need to peek when checking in which polygon a point is
* some more unsafe for things that are already checked
* generalise using `u32` in some place instead of `usize` 

```
group                                             main                        this PR
-----                                             ----                        -------
baking                                            1.02      4.6±0.06ms        1.00      4.5±0.06ms
get path Vec2(0.0, 0.0)-Vec2(0.0, 0.0)            1.21     12.0±0.12µs        1.00      9.9±0.10µs
get path Vec2(0.0, 0.0)-Vec2(575.0, 410.0)        1.22     12.0±0.14µs        1.00      9.9±0.12µs
get path Vec2(233.0, 323.0)                       1.08  1590.0±16.29µs        1.00  1470.1±19.35µs
get path Vec2(297.0, 438.0)-Vec2(575.0, 410.0)    1.58     64.8±0.52µs        1.00     41.1±0.41µs
get path Vec2(356.0, 166.0)                       1.09  1635.2±18.64µs        1.00  1503.2±18.61µs
get path Vec2(458.0, 47.0)-Vec2(575.0, 410.0)     1.14     24.2±0.26µs        1.00     21.2±0.24µs
get path Vec2(468.0, 584.0)                       1.09  1183.3±16.07µs        1.00  1087.9±29.04µs
get path Vec2(512.0, 170.0)                       1.09  1473.3±19.72µs        1.00  1351.1±24.13µs
get path Vec2(575.0, 410.0)-Vec2(0.0, 0.0)        1.30     16.4±0.15µs        1.00     12.6±0.15µs
get path Vec2(575.0, 410.0)-Vec2(458.0, 47.0)     1.10     11.9±0.16ms        1.00     10.9±0.15ms
get path Vec2(611.0, 658.0)                       1.09  1657.6±18.14µs        1.00  1521.2±21.64µs
get path Vec2(827.0, 678.0)                       1.09  1708.0±21.05µs        1.00  1572.6±19.49µs
get path Vec2(993.0, 290.0)                       1.09      3.2±0.03ms        1.00      2.9±0.03ms
is in mesh Vec2(131.0, 669.0)                     1.32      2.9±0.03µs        1.00      2.2±0.02µs
is in mesh Vec2(135.0, 360.0)                     1.60    892.4±7.17ns        1.00    556.8±5.48ns
is in mesh Vec2(22.0, 432.0)                      1.31  1476.8±16.24ns        1.00  1128.0±11.21ns
is in mesh Vec2(308.0, 147.0)                     1.72      2.9±0.04µs        1.00  1666.1±19.25ns
is in mesh Vec2(575.0, 410.0)                     1.71      4.2±0.04µs        1.00      2.5±0.02µs
is in mesh Vec2(728.0, 148.0)                     2.40      4.5±0.04µs        1.00  1864.5±24.99ns
is not in mesh Vec2(0.0, 0.0)                     1.22     12.1±0.12µs        1.00      9.9±0.10µs
is not in mesh Vec2(297.0, 438.0)                 1.57     64.9±0.54µs        1.00     41.4±0.51µs
is not in mesh Vec2(521.0, 90.0)                  1.69     68.0±1.30µs        1.00     40.2±0.42µs
is not in mesh Vec2(726.0, 470.0)                 1.71     71.1±0.66µs        1.00     41.7±0.59µs
is not in mesh Vec2(969.0, 726.0)                 2.19     59.7±0.59µs        1.00     27.2±0.28µs
```