### PR TITLE
use a bvh for baking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ async = []
 tracing = { version = "0.1", optional = true }
 hashbrown = { version = "0.12" }
 glam = { version = "0.21.3", features = ["approx"] }
-indexmap = "1.9"
 smallvec = { version = "1.9", features = ["union", "const_generics"] }
+bvh2d = "0.1"
 
 [dev-dependencies]
 criterion = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -397,13 +397,12 @@ impl Mesh {
     }
 
     #[cfg_attr(feature = "tracing", instrument(skip_all))]
-    fn get_point_location_unit_baked<'a>(&'a self, point: Vec2) -> u32 {
+    fn get_point_location_unit_baked(&self, point: Vec2) -> u32 {
         self.baked_polygons
             .as_ref()
             .unwrap()
             .contains_iterator(&point)
-            .filter(|index| self.point_in_polygon(point, &self.polygons[*index]))
-            .next()
+            .find(|index| self.point_in_polygon(point, &self.polygons[*index]))
             .map(|index| index as u32)
             .unwrap_or(u32::MAX)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,17 +17,19 @@ const PRECISION: f32 = 1000.0;
 use std::{cell::Cell, time::Instant};
 use std::{
     cmp::Ordering,
-    fmt::{self, Display},
+    fmt::{self, Debug, Display},
     hash::Hash,
     io,
     io::{BufRead, Read},
 };
 
+use bvh2d::{
+    aabb::{Bounded, AABB},
+    bvh2d::BVH2d,
+};
 use glam::Vec2;
-use hashbrown::HashSet;
 
 use helpers::Vec2Helper;
-use indexmap::IndexMap;
 use instance::{EdgeSide, InstanceStep};
 #[cfg(feature = "tracing")]
 use tracing::instrument;
@@ -60,8 +62,7 @@ pub struct Mesh {
     pub vertices: Vec<Vertex>,
     /// List of `Polygons` in this mesh
     pub polygons: Vec<Polygon>,
-    /// polygons that overlap a given x index
-    baked_polygons_x: IndexMap<i32, Vec<u32>>,
+    baked_polygons: Option<BVH2d>,
     #[cfg(feature = "stats")]
     pub(crate) scenarios: Cell<u32>,
 }
@@ -86,66 +87,52 @@ impl Hash for Root {
     }
 }
 
+struct BoundedPolygon {
+    aabb: (Vec2, Vec2),
+}
+
+impl Bounded for BoundedPolygon {
+    fn aabb(&self) -> AABB {
+        AABB::with_bounds(self.aabb.0, self.aabb.1)
+    }
+}
+
 impl Mesh {
     /// Remove pre-computed optimizations from the mesh. Call this if you modified the [`Mesh`].
     pub fn unbake(&mut self) {
-        self.baked_polygons_x.clear();
+        self.baked_polygons = None;
     }
 
     /// Pre-compute optimizations on the mesh
     pub fn bake(&mut self) {
-        // compute the axis aligned bounding box for each polygon
-        for polygon in &mut self.polygons {
-            polygon.aabb = polygon.vertices.iter().fold(
-                (Vec2::new(f32::MAX, f32::MAX), Vec2::ZERO),
-                |mut aabb, v| {
-                    if let Some(v) = self.vertices.get(*v as usize) {
-                        if v.coords.x < aabb.0.x {
-                            aabb.0.x = v.coords.x;
-                        }
-                        if v.coords.y < aabb.0.y {
-                            aabb.0.y = v.coords.y;
-                        }
-                        if v.coords.x > aabb.1.x {
-                            aabb.1.x = v.coords.x;
-                        }
-                        if v.coords.y > aabb.1.y {
-                            aabb.1.y = v.coords.y;
-                        }
-                    }
-                    aabb
-                },
-            );
-        }
-
-        self.baked_polygons_x = self
-            .vertices
-            .iter()
-            .map(|v| ((v.coords.x * PRECISION) as i32, vec![]))
-            .collect();
-        self.baked_polygons_x.sort_unstable_keys();
-
-        for (polygon_index, xs) in self
+        let bounded_polygons = self
             .polygons
-            .iter()
-            .map(|p| {
-                (
-                    (p.aabb.0.x * PRECISION) as i32,
-                    (p.aabb.1.x * PRECISION) as i32,
-                )
+            .iter_mut()
+            .map(|polygon| BoundedPolygon {
+                aabb: polygon.vertices.iter().fold(
+                    (Vec2::new(f32::MAX, f32::MAX), Vec2::ZERO),
+                    |mut aabb, v| {
+                        if let Some(v) = self.vertices.get(*v as usize) {
+                            if v.coords.x < aabb.0.x {
+                                aabb.0.x = v.coords.x;
+                            }
+                            if v.coords.y < aabb.0.y {
+                                aabb.0.y = v.coords.y;
+                            }
+                            if v.coords.x > aabb.1.x {
+                                aabb.1.x = v.coords.x;
+                            }
+                            if v.coords.y > aabb.1.y {
+                                aabb.1.y = v.coords.y;
+                            }
+                        }
+                        aabb
+                    },
+                ),
             })
-            .enumerate()
-        {
-            for (x_index, slice) in &mut self.baked_polygons_x {
-                if *x_index < xs.0 {
-                    continue;
-                }
-                slice.push(polygon_index as u32);
-                if *x_index > xs.1 {
-                    break;
-                }
-            }
-        }
+            .collect::<Vec<_>>();
+
+        self.baked_polygons = Some(BVH2d::build(&bounded_polygons));
     }
 
     /// Create a `Mesh` from a list of [`Vertex`] and [`Polygon`].
@@ -153,7 +140,7 @@ impl Mesh {
         let mut mesh = Mesh {
             vertices,
             polygons,
-            baked_polygons_x: IndexMap::default(),
+            baked_polygons: None,
             #[cfg(feature = "stats")]
             scenarios: Cell::new(0),
         };
@@ -389,7 +376,7 @@ impl Mesh {
         ]
         .iter()
         .map(|delta| {
-            if self.baked_polygons_x.is_empty() {
+            if self.baked_polygons.is_none() {
                 self.get_point_location_unit(point + *delta)
             } else {
                 self.get_point_location_unit_baked(point + *delta)
@@ -410,23 +397,15 @@ impl Mesh {
     }
 
     #[cfg_attr(feature = "tracing", instrument(skip_all))]
-    fn get_point_location_unit_baked(&self, point: Vec2) -> u32 {
-        let mut visited = HashSet::new();
-        for baked in self.baked_polygons_x.iter() {
-            if *baked.0 > (point.x * PRECISION) as i32 {
-                for i in baked.1.iter() {
-                    if visited.insert(i)
-                        && self.point_in_polygon(point, &self.polygons[*i as usize])
-                    {
-                        return *i;
-                    }
-                }
-            }
-            if *baked.0 > (point.x * PRECISION) as i32 {
-                break;
-            }
-        }
-        u32::MAX
+    fn get_point_location_unit_baked<'a>(&'a self, point: Vec2) -> u32 {
+        self.baked_polygons
+            .as_ref()
+            .unwrap()
+            .contains_iterator(&point)
+            .filter(|index| self.point_in_polygon(point, &self.polygons[*index]))
+            .next()
+            .map(|index| index as u32)
+            .unwrap_or(u32::MAX)
     }
 
     #[cfg_attr(feature = "tracing", instrument(skip_all))]
@@ -521,7 +500,6 @@ mod tests {
     }
 
     use glam::Vec2;
-    use indexmap::IndexMap;
 
     use crate::{helpers::*, Mesh, Path, Polygon, SearchNode, Vertex};
 
@@ -548,7 +526,7 @@ mod tests {
                 Polygon::new(vec![4, 5, 9, 8], true),
                 Polygon::new(vec![6, 7, 11, 10], true),
             ],
-            baked_polygons_x: IndexMap::default(),
+            baked_polygons: None,
             #[cfg(feature = "stats")]
             scenarios: std::cell::Cell::new(0),
         }
@@ -556,7 +534,8 @@ mod tests {
 
     #[test]
     fn point_in_polygon() {
-        let mesh = mesh_u_grid();
+        let mut mesh = mesh_u_grid();
+        mesh.bake();
         assert_eq!(mesh.get_point_location(Vec2::new(0.5, 0.5)), 0);
         assert_eq!(mesh.get_point_location(Vec2::new(1.5, 0.5)), 1);
         assert_eq!(mesh.get_point_location(Vec2::new(0.5, 1.5)), 3);
@@ -768,10 +747,21 @@ mod tests {
                 Polygon::new(vec![15, 18, 19, 16], true),
                 Polygon::new(vec![11, 17, 20, 21], true),
             ],
-            baked_polygons_x: IndexMap::default(),
+            baked_polygons: None,
             #[cfg(feature = "stats")]
             scenarios: std::cell::Cell::new(0),
         }
+    }
+
+    #[test]
+    fn paper_point_in_polygon() {
+        let mut mesh = mesh_from_paper();
+        mesh.bake();
+        assert_eq!(mesh.get_point_location(Vec2::new(0.5, 0.5)), u32::MAX);
+        assert_eq!(mesh.get_point_location(Vec2::new(2.0, 6.0)), 0);
+        assert_eq!(mesh.get_point_location(Vec2::new(2.0, 5.1)), 0);
+        assert_eq!(mesh.get_point_location(Vec2::new(2.0, 1.5)), 1);
+        assert_eq!(mesh.get_point_location(Vec2::new(4.0, 2.1)), 2);
     }
 
     #[test]

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -37,7 +37,6 @@ pub struct Polygon {
     /// A one way polygon is a polygon that has only one neighbour. This is used to speed up
     /// path finding, but not mandatory.
     pub is_one_way: bool,
-    pub(crate) aabb: (Vec2, Vec2),
 }
 
 impl Polygon {
@@ -47,7 +46,6 @@ impl Polygon {
     pub const EMPTY: Polygon = Polygon {
         vertices: vec![],
         is_one_way: false,
-        aabb: (Vec2::ZERO, Vec2::ZERO),
     };
 
     /// Creates a new `Polygon`.
@@ -55,7 +53,6 @@ impl Polygon {
         Polygon {
             vertices,
             is_one_way,
-            aabb: (Vec2::ZERO, Vec2::ZERO),
         }
     }
 
@@ -79,7 +76,6 @@ impl Polygon {
         Polygon {
             vertices,
             is_one_way,
-            aabb: (Vec2::ZERO, Vec2::ZERO),
         }
     }
 
@@ -150,14 +146,12 @@ impl Polygon {
 #[cfg(test)]
 mod tests {
     use crate::Polygon;
-    use glam::Vec2;
 
     #[test]
     fn edges_between() {
         let polygon = Polygon {
             vertices: vec![0, 1, 2, 3],
             is_one_way: false,
-            aabb: (Vec2::ZERO, Vec2::ONE),
         };
 
         for start in 0..6 {

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -30,7 +30,7 @@ impl Vertex {
 }
 
 /// A polygon in the navigation mesh.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Polygon {
     /// List of vertex making this polygon, in counter clockwise order.
     pub vertices: Vec<u32>,


### PR DESCRIPTION
For an increase in baking, an improvement in finding a point in the mesh

```
group                                             bvh                         main
-----                                             ---                         ----
baking                                            1.34      6.0±0.09ms        1.00       4.5±0.05ms
get path Vec2(0.0, 0.0)-Vec2(0.0, 0.0)            1.00    193.9±3.98ns        68.77     13.3±0.14µs
get path Vec2(0.0, 0.0)-Vec2(575.0, 410.0)        1.00    192.8±2.37ns        68.98     13.3±0.18µs
get path Vec2(233.0, 323.0)                       1.00  1433.2±13.58µs        1.01   1444.3±19.30µs
get path Vec2(297.0, 438.0)-Vec2(575.0, 410.0)    1.00    503.6±4.31ns        114.02    57.4±0.63µs
get path Vec2(356.0, 166.0)                       1.00  1468.9±14.06µs        1.00   1475.0±24.24µs
get path Vec2(458.0, 47.0)-Vec2(575.0, 410.0)     1.00     14.6±0.13µs        1.50      21.9±0.22µs
get path Vec2(468.0, 584.0)                       1.00  1057.9±15.76µs        1.00   1059.4±25.57µs
get path Vec2(512.0, 170.0)                       1.00  1322.0±18.64µs        1.00   1327.2±11.61µs
get path Vec2(575.0, 410.0)-Vec2(0.0, 0.0)        1.00    375.9±5.92ns        45.22     17.0±0.20µs
get path Vec2(575.0, 410.0)-Vec2(458.0, 47.0)     1.00     10.8±0.09ms        1.01      10.8±0.10ms
get path Vec2(611.0, 658.0)                       1.00  1483.1±17.37µs        1.01   1497.4±23.48µs
get path Vec2(827.0, 678.0)                       1.00  1533.2±14.68µs        1.01   1542.3±23.38µs
get path Vec2(993.0, 290.0)                       1.00      2.8±0.02ms        1.00       2.9±0.02ms
is in mesh Vec2(131.0, 669.0)                     1.00    182.4±1.49ns        16.85      3.1±0.03µs
is in mesh Vec2(135.0, 360.0)                     1.00    156.3±1.25ns        4.84     757.1±6.08ns
is in mesh Vec2(22.0, 432.0)                      1.00    172.5±1.91ns        9.19   1584.3±15.51ns
is in mesh Vec2(308.0, 147.0)                     1.00    346.7±3.57ns        6.77       2.3±0.02µs
is in mesh Vec2(575.0, 410.0)                     1.00    188.3±2.01ns        17.95      3.4±0.03µs
is in mesh Vec2(728.0, 148.0)                     1.00    262.7±2.76ns        9.65       2.5±0.02µs
is not in mesh Vec2(0.0, 0.0)                     1.00    183.8±4.19ns        73.35     13.5±0.15µs
is not in mesh Vec2(297.0, 438.0)                 1.00    504.3±5.42ns        115.50    58.2±0.54µs
is not in mesh Vec2(521.0, 90.0)                  1.00   883.2±11.62ns        62.51     55.2±0.67µs
is not in mesh Vec2(726.0, 470.0)                 1.00    517.2±5.26ns        108.48    56.1±0.58µs
is not in mesh Vec2(969.0, 726.0)                 1.00    335.0±3.99ns        112.53    37.7±0.35µs
```