### PR TITLE
Add serde behind a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ tracing = { version = "0.1", optional = true }
 hashbrown = { version = "0.13" }
 glam = { version = "0.23", features = ["approx"] }
 smallvec = { version = "1.9", features = ["union", "const_generics"] }
-bvh2d = { version = "0.3", git = "https://github.com/66OJ66/bvh2d" }
+bvh2d = { version = "0.3", git = "https://github.com/mockersf/bvh2d" }
 serde = { version = "1.0.164", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,15 @@ stats = []
 verbose = []
 async = []
 no-default-baking = []
+serde = ["glam/serde", "bvh2d/serde", "dep:serde"]
 
 [dependencies]
 tracing = { version = "0.1", optional = true }
 hashbrown = { version = "0.13" }
 glam = { version = "0.23", features = ["approx"] }
 smallvec = { version = "1.9", features = ["union", "const_generics"] }
-bvh2d = { version = "0.3", git = "https://github.com/mockersf/bvh2d" }
+bvh2d = { version = "0.3", git = "https://github.com/66OJ66/bvh2d" }
+serde = { version = "1.0.164", features = ["derive"], optional = true }
 
 [dev-dependencies]
 criterion = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,9 @@ use instance::{EdgeSide, InstanceStep};
 #[cfg(feature = "tracing")]
 use tracing::instrument;
 
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
+
 #[cfg(feature = "async")]
 mod async_helpers;
 mod helpers;
@@ -58,6 +61,7 @@ pub struct Path {
 
 /// A navigation mesh
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Mesh {
     /// List of `Vertex` in this mesh
     pub vertices: Vec<Vertex>,

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -6,8 +6,12 @@ use tracing::instrument;
 
 use glam::Vec2;
 
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
+
 /// A point that lies on an edge of a polygon in the navigation mesh.
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Vertex {
     /// Coordinates of that point.
     pub coords: Vec2,
@@ -31,6 +35,7 @@ impl Vertex {
 
 /// A polygon in the navigation mesh.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Polygon {
     /// List of vertex making this polygon, in counter clockwise order.
     pub vertices: Vec<u32>,


### PR DESCRIPTION
Hi,

Whilst https://github.com/vleue/polyanya/issues/24 is open, it would be useful if polyanya's meshes could be serialised/deserialised because:

- If using postcard (/other binary formats), it should be quicker to deserialize meshes from disk than generating and baking them at runtime
- This would allow meshes to be preprocessed for use in `bevy_pathmesh` once Bevy's asset system v2 is merged

This PR just adds serde derives behind a feature gate accordingly.

I've raised another PR [here](https://github.com/mockersf/bvh2d/pull/5) for adding the same to the `bvh2d` crate.