### PR TITLE
Fix missing data when writing mesh file

### DIFF
--- a/src/input/polyanya_file.rs
+++ b/src/input/polyanya_file.rs
@@ -105,9 +105,10 @@ impl PolyanyaFile {
         for vertex in &self.vertices {
             bytes.extend_from_slice(
                 format!(
-                    "{} {} {}\n",
+                    "{:.06} {:.06} {} {}\n",
                     vertex.coords.x,
                     vertex.coords.y,
+                    vertex.polygons.len(),
                     vertex
                         .polygons
                         .iter()

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -65,12 +65,14 @@ impl Polygon {
     }
 
     pub(crate) fn using(nb: usize, data: Vec<isize>) -> Self {
-        assert!(data.len() == nb * 2);
         let (vertices, neighbours) = data.split_at(nb);
         let vertices = vertices.iter().copied().map(|v| v as u32).collect();
         let neighbours = neighbours.to_vec();
         let mut found_trav = false;
-        let mut is_one_way = true;
+        // Hack to handle case where there are no neighbours in the file. In
+        // this case we want to assume it is not a one way. The correct fix is
+        // to update the polyanya file format to include the neighbours.
+        let mut is_one_way = !neighbours.is_empty();
         for neighbour in &neighbours {
             if *neighbour != -1 {
                 if found_trav {


### PR DESCRIPTION
This is a partial fix for https://github.com/vleue/polyanya/issues/42

When using `PolyanyaFile` to write a mesh file, the format doesn't quite match the specs. This PR fixes one of them and adds a workaround for the other.

Firstly, when writing the vertices, there is meant to be a count of the polygons written before the list, this was missing.

```
mesh
2
4 2
0.0 0.0 *2* 0 -1
...
```

Secondly, as originally reported in the issue is the neighbours aren't written. This isn't a huge issue as we don't seem to use them but it did mean we couldn't load the mesh file we wrote. Without calculating the neighbours, the workaround I add here is to set the `is_one_way` flag correctly if the neighbours list is empty.

Finally as a small bonus, I added a format limit to the coordinates to avoid annoying trailing `.0000001`'s in some numbers.

This leaves the output looking like (e.g.):
```
mesh
2
10 8
3.775000 2.675000 2 -1 5
3.775000 1.175000 4 -1 4 5 7
2.125000 1.175000 6 -1 0 1 3 4 6
2.125000 1.275000 2 -1 0
1.775000 1.275000 3 -1 0 1
1.775000 1.175000 4 -1 1 2 3
0.375000 1.175000 2 -1 2
0.375000 0.375000 4 -1 2 3 6
4.075000 0.375000 4 -1 4 6 7
4.075000 2.675000 3 -1 5 7
3 4 2 3
3 5 2 4
3 7 5 6
3 5 7 2
3 1 2 8
3 0 1 9
3 7 8 2
3 8 9 1
``` 

Compared to using [poly2mesh](https://bitbucket.org/dharabor/pathfinding/src/master/anyangle/polyanya/utils/poly2mesh.cpp) which generates this:

```
mesh
2
10 8
2.1250000000 1.1750000000 5 4 -1 0 3 6
1.7750000000 1.1750000000 5 3 0 1 -1 2
1.7750000000 1.2750000000 2 -1 1
2.1250000000 1.2750000000 3 -1 1 0
0.3750000000 1.1750000000 2 -1 2
0.3750000000 0.3750000000 4 6 3 2 -1
3.7750000000 2.6750000000 2 7 -1
4.0750000000 2.6750000000 3 7 5 -1
4.0750000000 0.3750000000 4 4 6 -1 5
3.7750000000 1.1750000000 4 4 5 7 -1
3 3 1 0 -1 1 3
3 3 2 1 0 -1 -1
3 5 1 4 -1 3 -1
3 5 0 1 2 6 0
3 9 0 8 5 -1 6
3 9 8 7 7 4 -1
3 8 0 5 -1 4 3
3 9 7 6 -1 5 -1
```

Edit: The original mesh without this change:
```
mesh
2
10 8
3.775 2.675 -1 5
3.775 1.1750001 -1 4 5 7
2.125 1.1750001 -1 0 1 3 4 6
2.125 1.275 -1 0
1.775 1.275 -1 0 1
1.775 1.1750001 -1 1 2 3
0.375 1.1750001 -1 2
0.375 0.375 -1 2 3 6
4.0750003 0.375 -1 4 6 7
4.0750003 2.675 -1 5 7
3 4 2 3
3 5 2 4
3 7 5 6
3 5 7 2
3 1 2 8
3 0 1 9
3 7 8 2
3 8 9 1
```