### PR TITLE
Fixes point not detected in polygon

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -5,7 +5,7 @@ use tracing::instrument;
 
 use crate::instance::EdgeSide;
 
-const EPSILON: f32 = 1e-2;
+const EPSILON: f32 = 1e-6;
 
 pub(crate) trait Vec2Helper {
     fn side(self, edge: (Vec2, Vec2)) -> EdgeSide;
@@ -221,6 +221,13 @@ mod tests {
             Vec2Helper::side(
                 Vec2::new(2.0, 2.0),
                 (Vec2::new(0.0, 0.0), Vec2::new(1.0, 1.0))
+            ),
+            EdgeSide::Edge
+        );
+        assert_ne!(
+            Vec2Helper::side(
+                Vec2::new(1.8266357, 1.2239377),
+                (Vec2::new(1.775, 1.275), Vec2::new(1.775, 1.175))
             ),
             EdgeSide::Edge
         );

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -5,7 +5,7 @@ use tracing::instrument;
 
 use crate::instance::EdgeSide;
 
-const EPSILON: f32 = 1e-6;
+const EPSILON: f32 = 1e-4;
 
 pub(crate) trait Vec2Helper {
     fn side(self, edge: (Vec2, Vec2)) -> EdgeSide;
@@ -224,6 +224,16 @@ mod tests {
             ),
             EdgeSide::Edge
         );
+
+        // Test epsilon value is large enough
+        assert_eq!(
+            Vec2Helper::side(
+                Vec2::new(5.585231282, 5.3880110045),
+                (Vec2::new(9.56, 7.42), Vec2::new(1.54, 3.32))
+            ),
+            EdgeSide::Edge
+        );
+        // Test epsilon value is small enough
         assert_ne!(
             Vec2Helper::side(
                 Vec2::new(1.8266357, 1.2239377),


### PR DESCRIPTION
This fixes some cases where a path was not being found. Specifically when a point was close to the edge it was detected as an `Edge` and not as part of the polygon. This test was quick heavy handed which caused a lot of false positives.

Most of the failures in mentioned in https://github.com/vleue/polyanya/issues/45 were caused by this.