### PR TITLE
helper function to find a point in the navmesh

### DIFF
--- a/src/layers.rs
+++ b/src/layers.rs
@@ -315,6 +315,7 @@ impl Layer {
         None
     }
 
+    #[inline(always)]
     pub(crate) fn get_closest_point_towards_inner(
         &self,
         point: Vec2,

--- a/src/layers.rs
+++ b/src/layers.rs
@@ -292,7 +292,7 @@ impl Layer {
                 return Some((new_point, poly));
             }
         }
-        return None;
+        None
     }
 
     /// Find the closest point in the layer in the given direction
@@ -312,7 +312,7 @@ impl Layer {
                 return Some(new_point);
             }
         }
-        return None;
+        None
     }
 
     pub(crate) fn get_closest_point_towards_inner(
@@ -331,7 +331,7 @@ impl Layer {
         if poly != u32::MAX {
             return Some((point, poly));
         }
-        return None;
+        None
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -571,7 +571,7 @@ impl Mesh {
                 }
             }
         }
-        return None;
+        None
     }
 }
 


### PR DESCRIPTION
- find the closest point around the specified coordinates
- find the closest point towards a direction
- if using the result to search a path, bypass searching for the point in the navmesh again