### PR TITLE
Removing unnecessary allocations

### DIFF
--- a/src/input/triangulation.rs
+++ b/src/input/triangulation.rs
@@ -132,10 +132,9 @@ impl Triangulation {
     }
 
     /// Add an obstacle delimited by the list of points on its edges.
-    pub fn add_obstacle(&mut self, edges: Vec<Vec2>) {
-        self.inner.interiors_push(LineString::from(
-            edges.iter().map(|v| (v.x, v.y)).collect::<Vec<_>>(),
-        ));
+    pub fn add_obstacle(&mut self, edges: impl IntoIterator<Item = Vec2>) {
+        self.inner
+            .interiors_push(LineString::from_iter(edges.into_iter().map(|v| (v.x, v.y))));
     }
 
     /// Add obstacles delimited by the list of points on their edges.
@@ -148,12 +147,7 @@ impl Triangulation {
             interiors
                 .into_iter()
                 .chain(obstacles.into_iter().map(|edges| {
-                    LineString(
-                        edges
-                            .iter()
-                            .map(|v| Coord::from((v.x, v.y)))
-                            .collect::<Vec<_>>(),
-                    )
+                    LineString::from_iter(edges.iter().map(|v| Coord::from((v.x, v.y))))
                 }))
                 .collect::<Vec<_>>(),
         );
@@ -728,17 +722,13 @@ mod inflate {
 
     fn round_line(line: &Line<f32>, distance: f32, arc_segments: u32) -> LineString<f32> {
         let Some(normal) = segment_normal(&line.start, &line.end) else {
-            return LineString::new(
-                (0..(arc_segments * 2))
-                    .map(|i| {
-                        let angle = i as f32 * TAU / (arc_segments * 2) as f32;
-                        Coord {
-                            x: line.start.x + angle.cos() * distance,
-                            y: line.start.y + angle.sin() * distance,
-                        }
-                    })
-                    .collect(),
-            );
+            return LineString::from_iter((0..(arc_segments * 2)).map(|i| {
+                let angle = i as f32 * TAU / (arc_segments * 2) as f32;
+                Coord {
+                    x: line.start.x + angle.cos() * distance,
+                    y: line.start.y + angle.sin() * distance,
+                }
+            }));
         };
         let mut vertices = Vec::with_capacity((arc_segments as usize + 2) * 2);
 

--- a/src/input/triangulation.rs
+++ b/src/input/triangulation.rs
@@ -138,7 +138,7 @@ impl Triangulation {
     }
 
     /// Add obstacles delimited by the list of points on their edges.
-    pub fn add_obstacles(&mut self, obstacles: impl IntoIterator<Item = Vec<Vec2>>) {
+    pub fn add_obstacles(&mut self, obstacles: impl IntoIterator<Item = impl IntoIterator<Item  = Vec2>>) {
         let (exterior, interiors) =
             std::mem::replace(&mut self.inner, GeoPolygon::new(LineString(vec![]), vec![]))
                 .into_inner();
@@ -147,7 +147,7 @@ impl Triangulation {
             interiors
                 .into_iter()
                 .chain(obstacles.into_iter().map(|edges| {
-                    LineString::from_iter(edges.iter().map(|v| Coord::from((v.x, v.y))))
+                    LineString::from_iter(edges.into_iter().map(|v| Coord::from((v.x, v.y))))
                 }))
                 .collect::<Vec<_>>(),
         );

--- a/src/stitching.rs
+++ b/src/stitching.rs
@@ -727,7 +727,7 @@ mod tests {
         ] {
             triangulation_a.add_obstacle(obstacle.clone());
             triangulation_b
-                .add_obstacle(obstacle.into_iter().map(|v| v - vec2(1.0, 0.0)).collect());
+                .add_obstacle(obstacle.into_iter().map(|v| v - vec2(1.0, 0.0)));
         }
         let mut mesh = Mesh::default();
         let mut layer_a = triangulation_a.as_layer();

--- a/tests/triangulation.rs
+++ b/tests/triangulation.rs
@@ -180,7 +180,6 @@ fn is_in_mesh_simplified() {
                 let (x, y) = angle.sin_cos();
                 vec2(x, y) * radius + vec2(5.0, 5.0)
             })
-            .collect(),
     );
     let polygons_before = triangulation.as_navmesh().layers[0].polygons.clone();
     triangulation.simplify(0.1);
@@ -216,7 +215,6 @@ fn is_in_mesh_overlapping_simplified() {
                 let (x, y) = angle.sin_cos();
                 vec2(x, y) * radius + vec2(5.0, 5.0)
             })
-            .collect(),
     );
     triangulation.add_obstacle(vec![
         vec2(2.5, 2.5),


### PR DESCRIPTION
Some instances of collect were unnecessary or redundant if the edges argument in add_obstacle is changed from Vec<Vec2> to impl IntoIterator<Item = Vec2>, as LineString can be directly constructed from an iterator.

On my machine (CPU: i5-12500H, 16 GB LPDDR5X 4800 MHz memory), this results in a speedup of 0.01s–0.02s when running tests