### PR TITLE
Optimizing trimesh by implementing vertex-to-poly lookup and reducing some iterators

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ glam = { version = "0.29", features = ["approx"] }
 smallvec = { version = "1.13", features = ["union", "const_generics"] }
 bvh2d = { version = "0.6", git = "https://github.com/mockersf/bvh2d" }
 serde = { version = "1.0", features = ["derive"], optional = true }
-spade = "=2.12.1"
+spade = "=2.10.0"
 geo = "0.29.0"
 log = "0.4"
 thiserror = "2.0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,10 @@ glam = { version = "0.29", features = ["approx"] }
 smallvec = { version = "1.13", features = ["union", "const_generics"] }
 bvh2d = { version = "0.6", git = "https://github.com/mockersf/bvh2d" }
 serde = { version = "1.0", features = ["derive"], optional = true }
-spade = "=2.10"
+spade = "=2.12.1"
 geo = "0.29.0"
 log = "0.4"
-thiserror = "1"
+thiserror = "2.0.10"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/src/input/trimesh.rs
+++ b/src/input/trimesh.rs
@@ -69,7 +69,7 @@ impl TryFrom<Trimesh> for Mesh {
                     let neighbor_index = polygons[index]
                         .vertices
                         .get_counterclockwise_neighbor(vertex_index);
-                    &unordered_vertices[neighbor_index].coords - vertex.coords
+                    unordered_vertices[neighbor_index].coords - vertex.coords
                 };
                 let edge_a = get_counterclockwise_edge(index_a);
                 let edge_b = get_counterclockwise_edge(index_b);

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -71,7 +71,7 @@ impl Polygon {
         // Hack to handle case where there are no neighbours in the file. In
         // this case we want to assume it is not a one way. The correct fix is
         // to update the polyanya file format to include the neighbours.
-        let mut is_one_way = neighbours.first().is_some();
+        let mut is_one_way = !neighbours.is_empty();
         for neighbour in neighbours {
             if *neighbour != -1 {
                 if found_trav {

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -67,13 +67,12 @@ impl Polygon {
     pub(crate) fn using(nb: usize, data: Vec<isize>) -> Self {
         let (vertices, neighbours) = data.split_at(nb);
         let vertices = vertices.iter().copied().map(|v| v as u32).collect();
-        let neighbours = neighbours.to_vec();
         let mut found_trav = false;
         // Hack to handle case where there are no neighbours in the file. In
         // this case we want to assume it is not a one way. The correct fix is
         // to update the polyanya file format to include the neighbours.
-        let mut is_one_way = !neighbours.is_empty();
-        for neighbour in &neighbours {
+        let mut is_one_way = neighbours.first().is_some();
+        for neighbour in neighbours {
             if *neighbour != -1 {
                 if found_trav {
                     is_one_way = false;


### PR DESCRIPTION
I made another set of micro optimizations, this time gains are a little bit larger (mainly in trimesh optimizations)

In `tests-aurora` arround 10% speedup