### PR TITLE
fix: Fix most clippy warnings

### DIFF
--- a/benches/baking.rs
+++ b/benches/baking.rs
@@ -5,7 +5,7 @@ fn baking(c: &mut Criterion) {
     let mut mesh: Mesh = PolyanyaFile::from_file("meshes/v2/aurora-merged.mesh")
         .try_into()
         .unwrap();
-    c.bench_function(&"baking".to_string(), |b| {
+    c.bench_function("baking", |b| {
         b.iter(|| {
             mesh.unbake();
             mesh.bake();

--- a/benches/merger.rs
+++ b/benches/merger.rs
@@ -131,7 +131,7 @@ const ARENA_OBSTACLES: [[Vec2; 6]; 5] = [
 ];
 
 fn merger(c: &mut Criterion) {
-    c.bench_function(&"merger arena".to_string(), |b| {
+    c.bench_function("merger arena", |b| {
         // Equivalent to the arena mesh
         let mut triangulation = Triangulation::from_outer_edges(&ARENA_OUTER_EDGE);
 
@@ -1969,7 +1969,7 @@ fn random_with_many_obstacles() -> Triangulation {
 }
 
 fn merger_many_overlapping(c: &mut Criterion) {
-    c.bench_function(&"merger many overlapping".to_string(), |b| {
+    c.bench_function("merger many overlapping", |b| {
         let triangulation = random_with_many_obstacles();
         let mesh: Mesh = triangulation.as_navmesh();
         b.iter(|| {
@@ -1981,7 +1981,7 @@ fn merger_many_overlapping(c: &mut Criterion) {
 }
 
 fn merger_many_overlapping_once(c: &mut Criterion) {
-    c.bench_function(&"merger many overlapping (once)".to_string(), |b| {
+    c.bench_function("merger many overlapping (once)", |b| {
         let triangulation = random_with_many_obstacles();
         let mesh: Mesh = triangulation.as_navmesh();
         b.iter(|| {

--- a/benches/path.rs
+++ b/benches/path.rs
@@ -5,7 +5,7 @@ use polyanya::{Mesh, PolyanyaFile};
 macro_rules! assert_delta {
     ($x:expr, $y:expr) => {
         let val = $x;
-        if !((val.length - $y).abs() < 0.001) {
+        if (val.length - $y).abs() >= 0.001 {
             assert_eq!(val.length, $y);
         }
         black_box(val);

--- a/benches/recast.rs
+++ b/benches/recast.rs
@@ -11,7 +11,7 @@ fn prepare_fullmesh(c: &mut Criterion) {
         serde_json::from_reader(File::open("meshes/recast/detail_mesh.json").unwrap()).unwrap();
     let full_mesh = RecastFullMesh::new(rasterised, detailed);
 
-    c.bench_function(&"recast - prepare fullmesh".to_string(), |b| {
+    c.bench_function("recast - prepare fullmesh", |b| {
         b.iter(|| {
             let full_mesh = full_mesh.clone();
             let mesh: Mesh = full_mesh.into();
@@ -28,9 +28,9 @@ fn find_path(c: &mut Criterion) {
     let full_mesh: polyanya::Mesh = RecastFullMesh::new(rasterised, detailed).into();
 
     let from = vec3(46.998413, 9.998184, 1.717747);
-    let to = vec3(20.703018, 18.651773, -80.770203);
+    let to = vec3(20.703018, 18.651773, -80.7702);
 
-    c.bench_function(&"recast - find path".to_string(), |b| {
+    c.bench_function("recast - find path", |b| {
         b.iter(|| {
             let path = full_mesh.path(from.xz(), to.xz()).unwrap();
             black_box(path);
@@ -46,9 +46,9 @@ fn find_path_with_height(c: &mut Criterion) {
     let full_mesh: polyanya::Mesh = RecastFullMesh::new(rasterised, detailed).into();
 
     let from = vec3(46.998413, 9.998184, 1.717747);
-    let to = vec3(20.703018, 18.651773, -80.770203);
+    let to = vec3(20.703018, 18.651773, -80.7702);
 
-    c.bench_function(&"recast - find path with height".to_string(), |b| {
+    c.bench_function("recast - find path with height", |b| {
         b.iter(|| {
             let path = full_mesh.path(from.xz(), to.xz()).unwrap();
             let path_with_height = path.path_with_height(from, to, &full_mesh);
@@ -65,10 +65,10 @@ fn enrich_path_with_height(c: &mut Criterion) {
     let full_mesh: polyanya::Mesh = RecastFullMesh::new(rasterised, detailed).into();
 
     let from = vec3(46.998413, 9.998184, 1.717747);
-    let to = vec3(20.703018, 18.651773, -80.770203);
+    let to = vec3(20.703018, 18.651773, -80.7702);
     let path = full_mesh.path(from.xz(), to.xz()).unwrap();
 
-    c.bench_function(&"recast - enrich path with height".to_string(), |b| {
+    c.bench_function("recast - enrich path with height", |b| {
         b.iter(|| {
             let path_with_height = path.path_with_height(from, to, &full_mesh);
             black_box(path_with_height);

--- a/benches/triangulation.rs
+++ b/benches/triangulation.rs
@@ -131,7 +131,7 @@ const ARENA_OBSTACLES: [[Vec2; 6]; 5] = [
 ];
 
 fn triangulation(c: &mut Criterion) {
-    c.bench_function(&"triangulation arena".to_string(), |b| {
+    c.bench_function("triangulation arena", |b| {
         b.iter(|| {
             // Equivalent to the arena mesh
             let mut triangulation = Triangulation::from_outer_edges(&ARENA_OUTER_EDGE);
@@ -149,7 +149,7 @@ fn triangulation(c: &mut Criterion) {
 }
 
 fn triangulation_bulk(c: &mut Criterion) {
-    c.bench_function(&"triangulation arena bulk add obstacles".to_string(), |b| {
+    c.bench_function("triangulation arena bulk add obstacles", |b| {
         b.iter(|| {
             // Equivalent to the arena mesh
             let mut triangulation = Triangulation::from_outer_edges(&ARENA_OUTER_EDGE);
@@ -168,7 +168,7 @@ fn triangulation_bulk(c: &mut Criterion) {
 }
 
 fn triangulation_overlapping(c: &mut Criterion) {
-    c.bench_function(&"triangulation arena overlapping".to_string(), |b| {
+    c.bench_function("triangulation arena overlapping", |b| {
         b.iter(|| {
             // Equivalent to the arena mesh
             let mut triangulation = Triangulation::from_outer_edges(&ARENA_OUTER_EDGE);
@@ -186,7 +186,7 @@ fn triangulation_overlapping(c: &mut Criterion) {
 }
 
 fn triangulation_square(c: &mut Criterion) {
-    c.bench_function(&"triangulation square".to_string(), |b| {
+    c.bench_function("triangulation square", |b| {
         b.iter(|| {
             let mut triangulation = Triangulation::from_outer_edges(&[
                 vec2(0.0, 0.0),
@@ -225,7 +225,7 @@ fn triangulation_square(c: &mut Criterion) {
 }
 
 fn triangulation_square_overlapping(c: &mut Criterion) {
-    c.bench_function(&"triangulation square overlapping".to_string(), |b| {
+    c.bench_function("triangulation square overlapping", |b| {
         b.iter(|| {
             let mut triangulation = Triangulation::from_outer_edges(&[
                 vec2(0.0, 0.0),
@@ -2082,7 +2082,7 @@ fn random_with_many_obstacles() -> Triangulation {
 }
 
 fn triangulation_many_overlapping(c: &mut Criterion) {
-    c.bench_function(&"triangulation many overlapping".to_string(), |b| {
+    c.bench_function("triangulation many overlapping", |b| {
         b.iter(|| {
             let triangulation = random_with_many_obstacles();
             let mesh: Mesh = triangulation.as_navmesh();
@@ -2092,36 +2092,30 @@ fn triangulation_many_overlapping(c: &mut Criterion) {
 }
 
 fn triangulation_many_overlapping_simplified(c: &mut Criterion) {
-    c.bench_function(
-        &"triangulation many overlapping (simplified)".to_string(),
-        |b| {
-            b.iter(|| {
-                let mut triangulation = random_with_many_obstacles();
-                triangulation.simplify(0.005);
-                let mesh: Mesh = triangulation.as_navmesh();
-                black_box(mesh);
-            })
-        },
-    );
+    c.bench_function("triangulation many overlapping (simplified)", |b| {
+        b.iter(|| {
+            let mut triangulation = random_with_many_obstacles();
+            triangulation.simplify(0.005);
+            let mesh: Mesh = triangulation.as_navmesh();
+            black_box(mesh);
+        })
+    });
 }
 
 fn triangulation_many_overlapping_inflated(c: &mut Criterion) {
-    c.bench_function(
-        &"triangulation many overlapping (inflated)".to_string(),
-        |b| {
-            b.iter(|| {
-                let mut triangulation = random_with_many_obstacles();
-                triangulation.set_agent_radius(0.1);
-                let mesh: Mesh = triangulation.as_navmesh();
-                black_box(mesh);
-            })
-        },
-    );
+    c.bench_function("triangulation many overlapping (inflated)", |b| {
+        b.iter(|| {
+            let mut triangulation = random_with_many_obstacles();
+            triangulation.set_agent_radius(0.1);
+            let mesh: Mesh = triangulation.as_navmesh();
+            black_box(mesh);
+        })
+    });
 }
 
 fn triangulation_many_overlapping_simplified_inflated(c: &mut Criterion) {
     c.bench_function(
-        &"triangulation many overlapping (simplified + inflated)".to_string(),
+        "triangulation many overlapping (simplified + inflated)",
         |b| {
             b.iter(|| {
                 let mut triangulation = random_with_many_obstacles();

--- a/examples/aurora.rs
+++ b/examples/aurora.rs
@@ -4,7 +4,7 @@ use polyanya::{Mesh, PolyanyaFile};
 macro_rules! assert_delta {
     ($x:expr, $y:expr) => {
         let val = $x;
-        if !((val.length - $y).abs() < 0.001) {
+        if (val.length - $y).abs() >= 0.001 {
             assert_eq!(val.length, $y);
         }
     };

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -242,7 +242,7 @@ mod tests {
         // Test epsilon value is large enough
         assert_eq!(
             Vec2Helper::side(
-                Vec2::new(5.585231282, 5.3880110045),
+                Vec2::new(5.5852313, 5.388011),
                 (Vec2::new(9.56, 7.42), Vec2::new(1.54, 3.32))
             ),
             EdgeSide::Edge

--- a/src/input/triangulation.rs
+++ b/src/input/triangulation.rs
@@ -760,7 +760,7 @@ mod inflate {
             (inflated_linestring, hole) = union.0.into_iter().next().unwrap().into_inner();
 
             if !hole.is_empty() {
-                holes.extend(hole.into_iter());
+                holes.extend(hole);
             }
             last = line.end;
         }

--- a/src/input/trimesh.rs
+++ b/src/input/trimesh.rs
@@ -270,8 +270,8 @@ mod tests {
         // where floating point errors cause total ordering to be violated.
         let mut vertices = Vec::new();
         for ray_index in 0..12 {
-            let angle = (ray_index as f32) * std::f32::consts::TAU / (12 as f32);
-            let angle_offset = ((7 as f32) * 0.1).sin() * 0.01;
+            let angle = (ray_index as f32) * std::f32::consts::TAU / 12_f32;
+            let angle_offset = (7_f32 * 0.1).sin() * 0.01;
             let dir = Vec2::from_angle(angle + angle_offset);
 
             for dist_index in 0..2 {

--- a/src/layers.rs
+++ b/src/layers.rs
@@ -397,7 +397,7 @@ impl Layer {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashSet, u32};
+    use std::collections::HashSet;
 
     #[cfg(feature = "detailed-layers")]
     use crate::helpers::line_intersect_segment;
@@ -495,7 +495,7 @@ mod tests {
             distance_start_to_root: 0.0,
             heuristic: from.distance(to),
         };
-        let (successors, arena) = dbg!(mesh.successors(search_node, to));
+        let (successors, _arena) = dbg!(mesh.successors(search_node, to));
         assert_eq!(successors.len(), 0);
         #[cfg(not(feature = "detailed-layers"))]
         assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -983,7 +983,7 @@ mod tests {
         ($x:expr, $y:expr) => {
             let val = $x;
             let expected = $y;
-            if !((val - expected).abs() < 0.01) {
+            if (val - expected).abs() >= 0.01 {
                 assert_eq!(val, expected);
             }
         };
@@ -1549,7 +1549,7 @@ mod tests {
         );
 
         let successor = successors.into_iter().next().unwrap();
-        let (successors, arena) = dbg!(mesh.successors(successor, to));
+        let (successors, _arena) = dbg!(mesh.successors(successor, to));
         dbg!(&successors[0]);
         assert_eq!(successors.len(), 1);
 

--- a/src/mesh_cleanup.rs
+++ b/src/mesh_cleanup.rs
@@ -107,8 +107,8 @@ impl Mesh {
 
             reordered_neighbors.push(reordered_neighbors_in_layer);
         }
-        for (layer, new) in self.layers.iter_mut().zip(reordered_neighbors.into_iter()) {
-            for (vertex, new) in layer.vertices.iter_mut().zip(new.into_iter()) {
+        for (layer, new) in self.layers.iter_mut().zip(reordered_neighbors) {
+            for (vertex, new) in layer.vertices.iter_mut().zip(new) {
                 vertex.is_corner = new.contains(&u32::MAX);
                 vertex.polygons = new;
             }

--- a/src/stitching.rs
+++ b/src/stitching.rs
@@ -636,10 +636,7 @@ mod tests {
         let indices_from = mesh.layers[0].get_vertices_on_segment(vec2(1.0, 0.0), vec2(1.0, 1.0));
         let indices_to = mesh.layers[1].get_vertices_on_segment(vec2(0.0, 0.0), vec2(0.0, 1.0));
 
-        let stitch_indices = indices_from
-            .into_iter()
-            .zip(indices_to.into_iter())
-            .collect();
+        let stitch_indices = indices_from.into_iter().zip(indices_to).collect();
 
         mesh.stitch_at_vertices(vec![((0, 1), stitch_indices)], false);
 
@@ -675,10 +672,7 @@ mod tests {
         let indices_from = mesh.layers[0].get_vertices_on_segment(vec2(1.0, 0.0), vec2(1.0, 1.0));
         let indices_to = mesh.layers[1].get_vertices_on_segment(vec2(0.0, 0.0), vec2(0.0, 1.0));
 
-        let stitch_indices = indices_from
-            .into_iter()
-            .zip(indices_to.into_iter())
-            .collect();
+        let stitch_indices = indices_from.into_iter().zip(indices_to).collect();
 
         mesh.stitch_at_vertices(vec![((0, 1), stitch_indices)], false);
 
@@ -758,10 +752,7 @@ mod tests {
         let indices_from = mesh.layers[0].get_vertices_on_segment(vec2(1.0, 0.0), vec2(1.0, 1.0));
         let indices_to = mesh.layers[1].get_vertices_on_segment(vec2(0.0, 0.0), vec2(0.0, 1.0));
 
-        let stitch_indices = indices_from
-            .into_iter()
-            .zip(indices_to.into_iter())
-            .collect();
+        let stitch_indices = indices_from.into_iter().zip(indices_to).collect();
 
         mesh.stitch_at_vertices(vec![((0, 1), stitch_indices)], false);
 
@@ -809,17 +800,11 @@ mod tests {
 
         let indices_from = mesh.layers[0].get_vertices_on_segment(vec2(1.0, 0.0), vec2(1.0, 1.0));
         let indices_to = mesh.layers[1].get_vertices_on_segment(vec2(0.0, 0.0), vec2(0.0, 1.0));
-        let stitch_indices_0_1 = indices_from
-            .into_iter()
-            .zip(indices_to.into_iter())
-            .collect();
+        let stitch_indices_0_1 = indices_from.into_iter().zip(indices_to).collect();
 
         let indices_from = mesh.layers[1].get_vertices_on_segment(vec2(1.0, 0.0), vec2(1.0, 1.0));
         let indices_to = mesh.layers[2].get_vertices_on_segment(vec2(0.0, 0.0), vec2(0.0, 1.0));
-        let stitch_indices_1_2 = indices_from
-            .into_iter()
-            .zip(indices_to.into_iter())
-            .collect();
+        let stitch_indices_1_2 = indices_from.into_iter().zip(indices_to).collect();
 
         mesh.stitch_at_vertices(
             vec![

--- a/tests/arena-merged.rs
+++ b/tests/arena-merged.rs
@@ -4,7 +4,7 @@ use polyanya::{Mesh, PolyanyaFile};
 macro_rules! assert_delta {
     ($x:expr, $y:expr) => {
         let val = $x.unwrap().length;
-        if !((val - $y).abs() < 0.0001) {
+        if (val - $y).abs() >= 0.0001 {
             assert_eq!(val, $y);
         }
     };

--- a/tests/arena-triangulation.rs
+++ b/tests/arena-triangulation.rs
@@ -4,7 +4,7 @@ use polyanya::{Mesh, Triangulation};
 macro_rules! assert_delta {
     ($x:expr, $y:expr) => {
         let val = $x.unwrap().length;
-        if !((val - $y).abs() < 0.0001) {
+        if (val - $y).abs() >= 0.0001 {
             assert_eq!(val, $y);
         }
     };

--- a/tests/arena.rs
+++ b/tests/arena.rs
@@ -4,7 +4,7 @@ use polyanya::{Mesh, PolyanyaFile};
 macro_rules! assert_delta {
     ($x:expr, $y:expr) => {
         let val = $x.unwrap().length;
-        if !((val - $y).abs() < 0.0001) {
+        if (val - $y).abs() >= 0.0001 {
             assert_eq!(val, $y);
         }
     };

--- a/tests/mesh-v3.rs
+++ b/tests/mesh-v3.rs
@@ -12,7 +12,7 @@ struct Scenario {
 macro_rules! assert_delta {
     ($x:expr, $y:expr) => {
         let val = $x.unwrap().length;
-        if !((val - $y).abs() < 0.0001) {
+        if (val - $y).abs() >= 0.0001 {
             assert_eq!(val, $y);
         }
     };
@@ -31,7 +31,7 @@ fn load_v3_scenario(path: &str) -> Vec<Scenario> {
         panic!("bad file, version header does not match 'version 1'")
     }
     lines
-        .filter_map(|line| line.ok())
+        .map_while(Result::ok)
         .map(|line| {
             let mut values = line.split_whitespace().skip(4);
             let start = Vec2::new(

--- a/tests/recast.rs
+++ b/tests/recast.rs
@@ -6,7 +6,7 @@ use polyanya::{Mesh, RecastFullMesh, RecastPolyMesh, RecastPolyMeshDetail};
 macro_rules! assert_delta {
     ($x:expr, $y:expr) => {
         let val = $x.unwrap().length;
-        if !((val - $y).abs() < 0.0001) {
+        if (val - $y).abs() >= 0.0001 {
             assert_eq!(val, $y);
         }
     };
@@ -19,7 +19,7 @@ fn detailed_mesh() {
     let mesh: Mesh = detailed_mesh.into();
 
     let start = vec3(46.998413, 9.998184, 1.717747);
-    let end = vec3(20.703018, 18.651773, -80.770203);
+    let end = vec3(20.703018, 18.651773, -80.770_2);
 
     let path = mesh.path(start.xz(), end.xz());
     assert!(path.is_some());
@@ -127,7 +127,7 @@ fn full_mesh() {
     let mesh: polyanya::Mesh = RecastFullMesh::new(rasterised, detailed).into();
 
     let start = vec3(46.998413, 9.998184, 1.717747);
-    let end = vec3(20.703018, 18.651773, -80.770203);
+    let end = vec3(20.703018, 18.651773, -80.770_2);
 
     let path = mesh.path(start.xz(), end.xz());
     assert!(path.is_some());


### PR DESCRIPTION
This fixes all clippy warnings except:

```
error: approximate value of `f{32, 64}::consts::SQRT_2` found
   --> tests/arena-triangulation.rs:163:9
    |
163 |         1.41421
    |         ^^^^^^^
    |
    = help: consider using the constant directly
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.94.0/index.html#approx_constant
    = note: `#[deny(clippy::approx_constant)]` on by default

error: approximate value of `f{32, 64}::consts::SQRT_2` found
  --> tests/arena-merged.rs:40:9
   |
40 |         1.41421
   |         ^^^^^^^
   |
   = help: consider using the constant directly
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.94.0/index.html#approx_constant
   = note: `#[deny(clippy::approx_constant)]` on by default

error: could not compile `polyanya` (test "arena-triangulation") due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: approximate value of `f{32, 64}::consts::SQRT_2` found
  --> tests/arena.rs:40:9
   |
40 |         1.41421
   |         ^^^^^^^
   |
   = help: consider using the constant directly
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.94.0/index.html#approx_constant
   = note: `#[deny(clippy::approx_constant)]` on by default

error: could not compile `polyanya` (test "arena-merged") due to 1 previous error
error: could not compile `polyanya` (test "arena") due to 1 previous error
```

I wasn't sure if you'd prefer adding an ignore or using the const here.

Most warnings have been fixed with:

```sh
cargo clippy --workspace --all-targets --all-features --fix
```