### PR TITLE
stop stepping the search once it runs out of nodes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -465,23 +465,16 @@ impl Mesh {
         let mut paths: Vec<Path> = vec![];
         // Limit search to avoid an infinite loop.
         for _ in 0..self.layers.iter().map(|l| l.polygons.len()).sum::<usize>() * 10 {
-            let _potential_path = match search_instance.next() {
+            match search_instance.next() {
                 #[cfg(not(feature = "detailed-layers"))]
                 InstanceStep::Found(path) => return Some(path),
                 #[cfg(feature = "detailed-layers")]
-                InstanceStep::Found(path) => Some(path),
-                InstanceStep::NotFound => {
-                    if paths.is_empty() {
-                        None
-                    } else {
-                        Some(paths.remove(0))
-                    }
-                }
-                InstanceStep::Continue => None,
-            };
-            #[cfg(feature = "detailed-layers")]
-            if let Some(path) = _potential_path {
-                paths.push(path);
+                InstanceStep::Found(path) => paths.push(path),
+                // The queue has run dry and nothing can refill it, so every further step
+                // is a pop from an empty heap. Keep going and we just burn the whole
+                // iteration limit before returning the answer we already have.
+                InstanceStep::NotFound => break,
+                InstanceStep::Continue => (),
             }
         }
         #[cfg(feature = "detailed-layers")]

--- a/tests/no_path.rs
+++ b/tests/no_path.rs
@@ -34,14 +34,11 @@ fn mesh_with_an_unreachable_island(copies: usize) -> Mesh {
     .as_layer();
     island.bake();
 
-    let mut layers = vec![island];
+    let mut mesh = Mesh::default();
+    mesh.layers.push(island);
     for _ in 0..copies {
-        layers.push(aurora_layer().clone());
+        mesh.layers.push(aurora_layer().clone());
     }
-    let mut mesh = Mesh {
-        layers,
-        ..Default::default()
-    };
     // nothing to stitch, but a multi-layer mesh still needs this pass: it is
     // what tags polygon indices with their layer
     mesh.stitch_at_vertices(vec![], false);

--- a/tests/no_path.rs
+++ b/tests/no_path.rs
@@ -1,0 +1,79 @@
+use std::time::Instant;
+
+use glam::{vec2, Vec2};
+use polyanya::{Mesh, PolyanyaFile, Triangulation};
+
+/// A real mesh plus a small square that is not stitched to it, so nothing can
+/// reach the square. Island detection is skipped as soon as there is more than
+/// one layer, so this is the case where the search really does have to run out
+/// of nodes to answer "no path".
+fn mesh_with_an_unreachable_island(copies: usize) -> Mesh {
+    let aurora: Mesh = PolyanyaFile::from_file("meshes/v2/aurora-merged.mesh")
+        .try_into()
+        .unwrap();
+    let island: Mesh = Triangulation::from_outer_edges(&[
+        vec2(1000.0, 1000.0),
+        vec2(1010.0, 1000.0),
+        vec2(1010.0, 1010.0),
+        vec2(1000.0, 1010.0),
+    ])
+    .as_navmesh();
+
+    let mut layers = vec![island.layers[0].clone()];
+    for _ in 0..copies {
+        layers.push(aurora.layers[0].clone());
+    }
+    let mut mesh = Mesh {
+        layers,
+        ..Default::default()
+    };
+    mesh.bake();
+    // nothing to stitch, but a multi-layer mesh still needs this pass: it is
+    // what tags polygon indices with their layer
+    mesh.stitch_at_vertices(vec![], false);
+    mesh
+}
+
+#[test]
+fn unreachable_target_is_not_a_path() {
+    let mesh = mesh_with_an_unreachable_island(1);
+    assert_eq!(
+        mesh.path(Vec2::new(1005.0, 1005.0), Vec2::new(233.0, 501.0)),
+        None
+    );
+    assert_eq!(
+        mesh.path(Vec2::new(233.0, 501.0), Vec2::new(1005.0, 1005.0)),
+        None
+    );
+}
+
+/// The search starts inside a two-polygon island, so it runs out of nodes after
+/// a handful of steps. What it costs to say so must follow from that, not from
+/// how many polygons the rest of the mesh happens to have.
+///
+/// This is a timing assertion, which is not lovely, but the effect is a factor
+/// of a hundred and I could not find a way to observe the step count from
+/// outside the crate. Happy to drop it or move it to `benches/` instead.
+#[test]
+fn saying_no_path_does_not_cost_the_whole_mesh() {
+    let small = mesh_with_an_unreachable_island(1);
+    let large = mesh_with_an_unreachable_island(8);
+
+    let time = |mesh: &Mesh| {
+        let (from, to) = (Vec2::new(1005.0, 1005.0), Vec2::new(233.0, 501.0));
+        // one call is a few microseconds once this is fixed, too short to time
+        let started = Instant::now();
+        for _ in 0..100 {
+            assert_eq!(mesh.path(from, to), None);
+        }
+        started.elapsed()
+    };
+
+    let small = time(&small);
+    let large = time(&large);
+    assert!(
+        large < small * 3,
+        "answering \"no path\" scaled with the size of the mesh the search never \
+         entered: {small:?} with one extra layer against {large:?} with eight"
+    );
+}

--- a/tests/no_path.rs
+++ b/tests/no_path.rs
@@ -1,33 +1,47 @@
+use std::sync::OnceLock;
 use std::time::Instant;
 
 use glam::{vec2, Vec2};
-use polyanya::{Mesh, PolyanyaFile, Triangulation};
+use polyanya::{Layer, Mesh, PolyanyaFile, Triangulation};
+
+/// Read and bake the aurora mesh once for the whole test binary, then clone it
+/// into each mesh that needs it. Baking is per layer and happens before
+/// stitching, so a clone of the baked layer is the same thing as baking a
+/// clone.
+fn aurora_layer() -> &'static Layer {
+    static AURORA: OnceLock<Layer> = OnceLock::new();
+    AURORA.get_or_init(|| {
+        let mut aurora: Mesh = PolyanyaFile::from_file("meshes/v2/aurora-merged.mesh")
+            .try_into()
+            .unwrap();
+        let mut layer = aurora.layers.remove(0);
+        layer.bake();
+        layer
+    })
+}
 
 /// A real mesh plus a small square that is not stitched to it, so nothing can
 /// reach the square. Island detection is skipped as soon as there is more than
 /// one layer, so this is the case where the search really does have to run out
 /// of nodes to answer "no path".
 fn mesh_with_an_unreachable_island(copies: usize) -> Mesh {
-    let aurora: Mesh = PolyanyaFile::from_file("meshes/v2/aurora-merged.mesh")
-        .try_into()
-        .unwrap();
-    let island: Mesh = Triangulation::from_outer_edges(&[
+    let mut island = Triangulation::from_outer_edges(&[
         vec2(1000.0, 1000.0),
         vec2(1010.0, 1000.0),
         vec2(1010.0, 1010.0),
         vec2(1000.0, 1010.0),
     ])
-    .as_navmesh();
+    .as_layer();
+    island.bake();
 
-    let mut layers = vec![island.layers[0].clone()];
+    let mut layers = vec![island];
     for _ in 0..copies {
-        layers.push(aurora.layers[0].clone());
+        layers.push(aurora_layer().clone());
     }
     let mut mesh = Mesh {
         layers,
         ..Default::default()
     };
-    mesh.bake();
     // nothing to stitch, but a multi-layer mesh still needs this pass: it is
     // what tags polygon indices with their layer
     mesh.stitch_at_vertices(vec![], false);


### PR DESCRIPTION
`InstanceStep::NotFound` means the queue is empty. Nothing refills it, so every step after
that is a pop from an empty heap — but the loop in `path_on_layers` kept going until it hit
the iteration limit, which is `polygons * 10` counted over the whole mesh.

Island detection hides this on a single layer: the check in front of the search catches a
disconnected target before a single node is generated. It is skipped as soon as there is
more than one layer, though, so on a stitched mesh every unreachable target pays the full
price, and the price has nothing to do with the part of the mesh the search actually walked.

Measured on `aurora-merged` with a two-polygon square added as a second, unstitched layer,
querying from inside that square:

| extra layers | before | after |
| --- | --- | --- |
| 1 × aurora | 690 µs | 4.8 µs |
| 8 × aurora | 5.5 ms | 5.0 µs |

The search looks at two polygons either way.

`detailed-layers` is left with the same semantics. Its `NotFound` arm used to pull the first
collected path off `paths` and push it back at the end, rotating the vec once per remaining
iteration; the results are sorted by length afterwards, so breaking out instead cannot change
which path is returned.

### Test

`tests/no_path.rs` builds the two-layer mesh above with one and with eight copies of aurora,
and asserts that answering "no path" does not get eight times slower when the extra polygons
are somewhere the search never goes. That is a timing assertion, which I am not thrilled
about, but the ratio is the thing being fixed and I could not find a way to observe the step
count from outside the crate. Happy to drop it or move it to `benches/` if you would rather.

One thing that came up while writing it: a `Mesh` assembled by pushing layers into
`Mesh::layers` is not usable until `stitch_at_vertices` has run, even when there is nothing
to stitch, because that is what tags polygon indices with their layer. Without it the search
reads layer 1's indices as layer 0 and either panics or walks nonsense adjacency. The test
calls it with an empty list. Might be worth a line in the docs somewhere.
