### PR TITLE
don't bake a layer that has no polygons

### DIFF
--- a/src/layers.rs
+++ b/src/layers.rs
@@ -106,8 +106,15 @@ impl Layer {
     /// Uses a BVH. This is useful at the start of the pathfinding, to get the containing polygons
     /// for the start and end point. It can also be used through [`Self::point_in_mesh`] to check
     /// if a point is in the mesh.
+    ///
+    /// A layer without polygons is left unbaked: there is no tree to build, and every reader of
+    /// the BVH already falls back to the linear scan when it is missing.
     #[cfg_attr(feature = "tracing", instrument(skip_all))]
     pub fn bake_polygon_finder(&mut self) {
+        if self.polygons.is_empty() {
+            self.baked_polygons = None;
+            return;
+        }
         let bounded_polygons = self
             .polygons
             .iter_mut()

--- a/tests/empty-layer.rs
+++ b/tests/empty-layer.rs
@@ -1,0 +1,47 @@
+use glam::vec2;
+use polyanya::{Layer, Mesh, Triangulation};
+
+/// The minimal reproduction: baking a layer that holds no polygons used to
+/// recurse forever in `BVH2d::build` and abort the process with a stack
+/// overflow.
+#[test]
+fn baking_a_layer_without_polygons_returns() {
+    let mut layer = Layer::default();
+    layer.bake();
+
+    let mesh = Mesh {
+        layers: vec![layer],
+        ..Default::default()
+    };
+    assert!(!mesh.point_in_mesh(vec2(0.0, 0.0)));
+}
+
+/// How one gets an empty layer without writing one by hand: an obstacle
+/// covering the whole outline leaves nothing to triangulate. A chunked mesh
+/// meets this whenever a chunk falls entirely inside a river or a city block.
+#[test]
+fn a_layer_covered_by_an_obstacle_bakes() {
+    let outline = [
+        vec2(0.0, 0.0),
+        vec2(10.0, 0.0),
+        vec2(10.0, 10.0),
+        vec2(0.0, 10.0),
+    ];
+    let mut triangulation = Triangulation::from_outer_edges(&outline);
+    triangulation.add_obstacle(vec![
+        vec2(-1.0, -1.0),
+        vec2(-1.0, 11.0),
+        vec2(11.0, 11.0),
+        vec2(11.0, -1.0),
+    ]);
+
+    let mut layer = triangulation.as_layer();
+    assert!(layer.polygons.is_empty());
+    layer.bake();
+
+    let mesh = Mesh {
+        layers: vec![layer],
+        ..Default::default()
+    };
+    assert!(!mesh.point_in_mesh(vec2(5.0, 5.0)));
+}


### PR DESCRIPTION
`Layer::bake()` on a layer that holds no polygons kills the process with a stack overflow.

`BVH2d::build` has no base case for an empty shape list. With zero shapes `centroid_bounds`
stays `AABB::EMPTY`, so `split_axis_size` comes out `-inf`, the `< EPSILON` branch splits
`indices` in half at `0`, and both halves are empty again — the call recurses into two copies
of itself forever. The stack size is irrelevant: it aborts on a 2 MiB worker thread and on an
8 MiB main thread alike, with `fatal runtime error: stack overflow` and no backtrace.

`Layer::new` rejects an empty polygon list, so this only reaches layers built another way:
`Triangulation::as_layer` when an obstacle covers the whole outline, or a layer assembled
directly. I met it on a chunked city mesh — 140 chunks over a map that includes a river, and
four of those chunks are covered by obstacles end to end, so they hold no free space at all.
Those four layers are built correctly; baking them killed the app, between the log line for
chunking and the one for baking, from an async worker with nothing to point at.

Guarding in `bake_polygon_finder` looked better than rejecting an empty layer: it is a legal
member of a multi-layer mesh, and every reader of `baked_polygons` already branches on `None`
into `get_point_locations_unit`, whose linear scan over zero polygons correctly answers that
the point is not on the mesh. `bake_islands_detection` is already fine on an empty layer — its
`find` returns `None` on the first look.

The root cause belongs to bvh2d and could be fixed there as well, but an empty input has no
tree to build either way, so not calling it is the cheaper half of that fix.

### Test

`tests/empty-layer.rs`. `Layer::default().bake()` is the whole minimal reproduction; the second
test arrives at an empty layer the way a user does, from a `Triangulation` whose obstacle covers
its outline. On `main` both abort the test binary (`signal: 6, SIGABRT` after
`fatal runtime error: stack overflow`); with the guard both pass.

The rest of the suite is unchanged, with `--features detailed-layers,serde,no-default-baking`
as well as on defaults.
